### PR TITLE
Fix override errors on build

### DIFF
--- a/src/Prestige.cpp
+++ b/src/Prestige.cpp
@@ -7,7 +7,7 @@
 
 auto& prestigeConfigSettings = PrestigeConfigSettings::Instance();
 
-void PrestigePlayerScript::OnLogin(Player* player)
+void PrestigePlayerScript::OnPlayerLogin(Player* player)
 {
     if (!player)
     {
@@ -51,7 +51,7 @@ void CheckForUpdatedMaxStats(Player* player)
     }
 }
 
-void PrestigePlayerScript::OnLogout(Player* player)
+void PrestigePlayerScript::OnPlayerLogout(Player* player)
 {
     if (!player)
     {
@@ -637,7 +637,7 @@ void PrestigeWorldScript::OnAfterConfigLoad(bool reload)
     LoadPrestigeStats();
 }
 
-void PrestigePlayerScript::OnLevelChanged(Player* player, uint8 oldLevel)
+void PrestigePlayerScript::OnPlayerLevelChanged(Player* player, uint8 oldLevel)
 {
     if (oldLevel == prestigeConfigSettings.GetIntendedMaxLevel() && player->GetLevel() == sWorld->getIntConfig(CONFIG_MAX_PLAYER_LEVEL))
     {
@@ -1044,7 +1044,7 @@ void PrestigeResistanceStatsMenu(Player* player)
         return;
 }
 
-void PrestigePlayerScript::OnGossipSelect(Player* player, uint32 menu_id, uint32 sender, uint32 action)
+void PrestigePlayerScript::OnPlayerGossipSelect(Player* player, uint32 menu_id, uint32 sender, uint32 action)
 {
     if (action == PRESTIGE_GOSSIP_ALLOCATE_MAIN_MENU)
     {

--- a/src/Prestige.h
+++ b/src/Prestige.h
@@ -361,13 +361,13 @@ class PrestigePlayerScript : public PlayerScript
 public:
     PrestigePlayerScript() : PlayerScript("PrestigePlayerScript") { }
 
-    virtual void OnLogin(Player* /*player*/) override;
-    virtual void OnLogout(Player* /*player*/) override;
+    virtual void OnPlayerLogin(Player* /*player*/) override;
+    virtual void OnPlayerLogout(Player* /*player*/) override;
     virtual void OnPlayerLeaveCombat(Player* /*player*/) override;
-    virtual void OnGossipSelect(Player* player, uint32 menu_id, uint32 sender, uint32 action) override;
+    virtual void OnPlayerGossipSelect(Player* player, uint32 menu_id, uint32 sender, uint32 action) override;
     void HandlePrestigeStatAllocation(Player* /*player*/, uint32 /*attribute*/, bool /*reset*/);
     std::string GetPrestigeStatName(uint32 /*attribute*/);
-    virtual void OnLevelChanged(Player* /*player*/, uint8 /*oldLevel*/) override;
+    virtual void OnPlayerLevelChanged(Player* /*player*/, uint8 /*oldLevel*/) override;
     virtual void OnPlayerEnterCombat(Player* /*player*/, Unit* /*enemy*/) override;
 };
 


### PR DESCRIPTION
Fix the following errors on build:

OnLogin -> OnPlayerLogin
OnLogout -> OnPlayerLogout
OnGossipSelect -> OnPlayerGossipSelect
OnLevelChanged -> OnPlayerLevelChanged